### PR TITLE
fix: show `doctype` code in html question

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 - Perbedaan HTML vs XHTML?
 - Perbedaan element dan tag HTML
 - Yang dimaksud dengan semantic HTML
-- Apa fungsi dari "<!DOCTYPE html>" diawal file HTML?
+- Apa fungsi dari `<!DOCTYPE html>` diawal file HTML?
 
 ## CSS
 


### PR DESCRIPTION
The `<!doctype>` code in the HTML question list can't be seen unless the question is read from raw code.